### PR TITLE
add mapping of auto start plugin property

### DIFF
--- a/sbp-spring-boot-starter/src/main/java/org/laxture/sbp/spring/boot/SbpAutoConfiguration.java
+++ b/sbp-spring-boot-starter/src/main/java/org/laxture/sbp/spring/boot/SbpAutoConfiguration.java
@@ -144,6 +144,7 @@ public class SbpAutoConfiguration {
 			}
 		};
 
+		pluginManager.setAutoStartPlugin(properties.isAutoStartPlugin());
 		pluginManager.setProfiles(properties.getPluginProfiles());
 		pluginManager.presetProperties(flatProperties(properties.getPluginProperties()));
 		pluginManager.setExactVersionAllowed(properties.isExactVersionAllowed());


### PR DESCRIPTION
When I want to disable the autostart function with the property "spring.sbp.auto-start-plugin", I see that it is not taken into account. So I add the consideration of this parameter.