### PR TITLE
Add thymeleaf plugin configurer

### DIFF
--- a/sbp-spring-boot-starter-thymeleaf/build.gradle
+++ b/sbp-spring-boot-starter-thymeleaf/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group = 'org.laxture.sbp'
+
+dependencies {
+    api project(':sbp-core')
+
+    implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
+}

--- a/sbp-spring-boot-starter-thymeleaf/src/main/java/org/laxture/sbp/spring/boot/SbpThymeleafConfigurer.java
+++ b/sbp-spring-boot-starter-thymeleaf/src/main/java/org/laxture/sbp/spring/boot/SbpThymeleafConfigurer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.laxture.sbp.spring.boot;
+
+import org.laxture.sbp.spring.boot.IPluginConfigurer;
+import org.laxture.sbp.spring.boot.SpringBootstrap;
+import org.springframework.context.support.GenericApplicationContext;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+
+/**
+ * @author <a href="https://github.com/kenpb">Kenneth P. Barquero</a>
+ */
+public class SbpThymeleafConfigurer implements IPluginConfigurer {
+
+    @Override
+    public String[] excludeConfigurations() {
+        return new String[] {
+                "org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration"
+        };
+    }
+
+    @Override
+    public void onBootstrap(SpringBootstrap bootstrap, GenericApplicationContext pluginApplicationContext) {
+        SpringTemplateEngine templateEngine = (SpringTemplateEngine) bootstrap.getMainApplicationContext()
+                .getBean("templateEngine");
+        templateEngine.addTemplateResolver(this.pluginTemplateResolver(pluginApplicationContext));
+    }
+
+    SpringResourceTemplateResolver pluginTemplateResolver(GenericApplicationContext pluginApplicationContext) {
+        SpringResourceTemplateResolver resolver = new SpringResourceTemplateResolver();
+        resolver.setApplicationContext(pluginApplicationContext);
+        resolver.setPrefix("/templates/");
+        resolver.setSuffix(".html");
+        return resolver;
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ include 'sbp-core',
         'sbp-adapter-3',
         'sbp-spring-boot-starter',
         'sbp-spring-boot-springdoc-starter',
+        'sbp-spring-boot-starter-thymeleaf',
 
         'demo-shared',
         'demo-security',


### PR DESCRIPTION
Hello,

This starter adds a basic `IPluginConfigurer`, `SbpThymeleafConfigurer` that Thymeleaf  uses to load templates from the plugins, to be honest, I have no idea how gradle works so I couldn't get the project to compile but hopefully, since the code is fairly simple, I'm not missing anything, let me know if any changes are required.

As a basic implementation it hard-codes the suffix and prefix for the templates in the plugin so its limited to `/templates/` as the folder and `.html` for the templates, I would like to improve this, do you think having individual configuration for each plugin is worth pursuing or should all the plugins just "inherit" the main app template resolver configuration?

Salutations